### PR TITLE
Fix deprecated duplicate macro exports

### DIFF
--- a/src/der/mod.rs
+++ b/src/der/mod.rs
@@ -5,14 +5,14 @@ pub mod length;
 /// The Intermediate Type
 pub mod intermediate;
 
-#[cfg(test)]
-mod test;
-
 /// DER Trait
 pub mod der;
 #[doc(hidden)]
 #[macro_use]
 pub mod macros;
+
+#[cfg(test)]
+mod test;
 
 pub use self::tag::*;
 pub use self::length::*;

--- a/src/der/test.rs
+++ b/src/der/test.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-include!("macros.rs");
-
 #[test]
 fn decode_tag_bytes() {
     for i in 0..32000 {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/50143 for more details.