### PR TITLE
Upgrade to Rust 2018 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Rahix/eagre-asn1"
 readme = "README.md"
 keywords = ["asn1", "der", "serialization"]
 license = "MIT/Apache-2.0"
-
+edition = "2018"
 
 [dependencies]
 byteorder = "0.4.2"

--- a/examples/der_test.rs
+++ b/examples/der_test.rs
@@ -8,7 +8,7 @@ struct User {
     pub male: bool,
 }
 
-der_sequence!{
+der_sequence! {
     User:
     name: NOTAG TYPE String,
     male: NOTAG TYPE bool,

--- a/examples/sequence_poc.rs
+++ b/examples/sequence_poc.rs
@@ -19,26 +19,26 @@ impl DER for Foo {
         asn1::der::ContentType::Constructed
     }
 
-    fn der_encode_content(&self, w: &mut ::std::io::Write) -> ::std::io::Result<()> {
-        try!(try!(self.a.der_intermediate()).encode_explicit(12, asn1::der::Class::Application, w));
-        try!(try!(self.b.der_intermediate()).encode_explicit(8, asn1::der::Class::ContextSpecific, w));
+    fn der_encode_content(&self, w: &mut dyn ::std::io::Write) -> ::std::io::Result<()> {
+        self.a
+            .der_intermediate()?
+            .encode_explicit(12, asn1::der::Class::Application, w)?;
+        self.b
+            .der_intermediate()?
+            .encode_explicit(8, asn1::der::Class::ContextSpecific, w)?;
         Ok(())
     }
 
-    fn der_decode_content(r: &mut ::std::io::Read, _: usize) -> ::std::io::Result<Self> {
-        let a: i32 = try!(asn1::der::DER::der_from_intermediate(try!(asn1::der::Intermediate::decode_explicit(r)).2));
-        let b: bool = try!(asn1::der::DER::der_from_intermediate(try!(asn1::der::Intermediate::decode_explicit(r)).2));
-        Ok(Foo {
-            a: a,
-            b: b,
-        })
+    fn der_decode_content(r: &mut dyn ::std::io::Read, _: usize) -> ::std::io::Result<Self> {
+        let a: i32 =
+            asn1::der::DER::der_from_intermediate(asn1::der::Intermediate::decode_explicit(r)?.2)?;
+        let b: bool =
+            asn1::der::DER::der_from_intermediate(asn1::der::Intermediate::decode_explicit(r)?.2)?;
+        Ok(Foo { a: a, b: b })
     }
 }
 
 fn main() {
-    let foo = Foo {
-        a: 12,
-        b: true,
-    };
+    let foo = Foo { a: 12, b: true };
     assert_eq!(foo, Foo::der_from_bytes(foo.der_bytes().unwrap()).unwrap());
 }

--- a/src/der/mod.rs
+++ b/src/der/mod.rs
@@ -1,9 +1,9 @@
-/// Tag encoding/decoding
-pub mod tag;
-/// Length encoding/decoding
-pub mod length;
 /// The Intermediate Type
 pub mod intermediate;
+/// Length encoding/decoding
+pub mod length;
+/// Tag encoding/decoding
+pub mod tag;
 
 /// DER Trait
 pub mod der;
@@ -14,10 +14,10 @@ pub mod macros;
 #[cfg(test)]
 mod test;
 
-pub use self::tag::*;
-pub use self::length::*;
-pub use self::intermediate::Intermediate;
 pub use self::der::DER;
+pub use self::intermediate::Intermediate;
+pub use self::length::*;
+pub use self::tag::*;
 
 /// DER Universal Tag Values
 #[derive(Debug, Copy, Clone)]

--- a/src/der/test.rs
+++ b/src/der/test.rs
@@ -57,15 +57,29 @@ fn decode_length() {
 
 #[test]
 fn serialize_bool() {
-    assert_eq!(true,
-               bool::der_from_bytes(true.der_bytes().unwrap()).unwrap());
-    assert_eq!(false,
-               bool::der_from_bytes(false.der_bytes().unwrap()).unwrap());
+    assert_eq!(
+        true,
+        bool::der_from_bytes(true.der_bytes().unwrap()).unwrap()
+    );
+    assert_eq!(
+        false,
+        bool::der_from_bytes(false.der_bytes().unwrap()).unwrap()
+    );
 }
 
 #[test]
 fn serialize_i32() {
-    for i in vec![::std::i32::MAX, 65535, 8, 1, 0, -1, -8, -65535, -::std::i32::MAX] {
+    for i in vec![
+        ::std::i32::MAX,
+        65535,
+        8,
+        1,
+        0,
+        -1,
+        -8,
+        -65535,
+        -::std::i32::MAX,
+    ] {
         assert_eq!(i, i32::der_from_bytes(i.der_bytes().unwrap()).unwrap());
     }
 }
@@ -80,12 +94,10 @@ fn i32_no_panic_but_err() {
 
 #[test]
 fn serialize_string() {
-    assert_eq!("ThisIsATestWithUtf8: ∅ ".to_string(),
-               String::der_from_bytes("ThisIsATestWithUtf8: ∅ "
-                       .to_string()
-                       .der_bytes()
-                       .unwrap())
-                   .unwrap());
+    assert_eq!(
+        "ThisIsATestWithUtf8: ∅ ".to_string(),
+        String::der_from_bytes("ThisIsATestWithUtf8: ∅ ".to_string().der_bytes().unwrap()).unwrap()
+    );
 }
 
 #[test]
@@ -113,7 +125,7 @@ struct TestStruct {
     pub gamma: String,
 }
 
-der_sequence!{TestStruct:
+der_sequence! {TestStruct:
     alpha: NOTAG TYPE i32,
     beta: EXPLICIT TAG CONTEXT 42; TYPE bool,
     gamma: IMPLICIT TAG APPLICATION 397; TYPE String,
@@ -128,8 +140,10 @@ fn serialize_sequence() {
         beta: false,
         gamma: "Hello World".to_string(),
     };
-    assert_eq!(data,
-               TestStruct::der_from_bytes(data.der_bytes().unwrap()).unwrap());
+    assert_eq!(
+        data,
+        TestStruct::der_from_bytes(data.der_bytes().unwrap()).unwrap()
+    );
     // let mut f = File::create("test.ber").unwrap();
     // f.write_all(&data.der_bytes().unwrap()).unwrap();
 }
@@ -146,8 +160,10 @@ der_enumerated!(TestEnum, Alpha, Beta, Gamma);
 #[test]
 fn serialize_enumerated() {
     for val in vec![TestEnum::Alpha, TestEnum::Beta, TestEnum::Gamma] {
-        assert_eq!(val,
-                   TestEnum::der_from_bytes(val.der_bytes().unwrap()).unwrap());
+        assert_eq!(
+            val,
+            TestEnum::der_from_bytes(val.der_bytes().unwrap()).unwrap()
+        );
     }
 }
 
@@ -158,7 +174,7 @@ enum TestChoice {
     Gamma(String),
 }
 
-der_choice!{TestChoice:
+der_choice! {TestChoice:
     Alpha: NOTAG TYPE i32,
     Beta: EXPLICIT TAG CONTEXT 42; TYPE bool,
     Gamma: IMPLICIT TAG APPLICATION 397; TYPE String,
@@ -166,10 +182,14 @@ der_choice!{TestChoice:
 
 #[test]
 fn serialize_choice() {
-    for val in vec![TestChoice::Alpha(1024),
-                    TestChoice::Beta(false),
-                    TestChoice::Gamma("Hello World".to_string())] {
-        assert_eq!(val,
-                   TestChoice::der_from_bytes(val.der_bytes().unwrap()).unwrap());
+    for val in vec![
+        TestChoice::Alpha(1024),
+        TestChoice::Beta(false),
+        TestChoice::Gamma("Hello World".to_string()),
+    ] {
+        assert_eq!(
+            val,
+            TestChoice::der_from_bytes(val.der_bytes().unwrap()).unwrap()
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,11 @@
 //! ```
 //!
 
-#![deny(missing_docs,
-        missing_debug_implementations, missing_copy_implementations,
-        )]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations
+)]
 
 #[doc(hidden)]
 extern crate byteorder;
@@ -81,5 +83,5 @@ macro_rules! debug_xer {
                 write!(f, "{}", ::std::string::String::from_utf8(stream).unwrap())
             }
         }
-    }
+    };
 }

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,5 +1,5 @@
-use std::io::{self, Write, Read};
-use der::*;
+use crate::der::*;
+use std::io::{self, Read, Write};
 
 /// Asn1 Any Type
 ///
@@ -26,7 +26,9 @@ pub struct Any {
 impl Any {
     /// Create a new Any object from a inner value
     pub fn new<T: DER>(val: T) -> io::Result<Any> {
-        Ok(Any { i: try!(val.der_intermediate()) })
+        Ok(Any {
+            i: val.der_intermediate()?,
+        })
     }
 
     /// Resolve the inner value of an Any object
@@ -44,11 +46,11 @@ impl DER for Any {
         unimplemented!() // Same as universal tag
     }
 
-    fn der_encode_content(&self, _: &mut Write) -> io::Result<()> {
+    fn der_encode_content(&self, _: &mut dyn Write) -> io::Result<()> {
         unimplemented!()
     }
 
-    fn der_decode_content(_: &mut Read, _: usize) -> io::Result<Self> {
+    fn der_decode_content(_: &mut dyn Read, _: usize) -> io::Result<Self> {
         unimplemented!()
     }
 

--- a/src/types/null.rs
+++ b/src/types/null.rs
@@ -1,5 +1,5 @@
-use std::io::{self, Write, Read};
-use der::*;
+use crate::der::*;
+use std::io::{self, Read, Write};
 
 /// Asn1 Null Type
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -14,14 +14,16 @@ impl DER for Null {
         ContentType::Primitive
     }
 
-    fn der_encode_content(&self, _: &mut Write) -> io::Result<()> {
+    fn der_encode_content(&self, _: &mut dyn Write) -> io::Result<()> {
         Ok(())
     }
 
-    fn der_decode_content(_: &mut Read, length: usize) -> io::Result<Self> {
+    fn der_decode_content(_: &mut dyn Read, length: usize) -> io::Result<Self> {
         if length != 0 {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput,
-                                      "Null Type with size bigger than zero"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Null Type with size bigger than zero",
+            ));
         }
         Ok(Null)
     }

--- a/src/types/strings.rs
+++ b/src/types/strings.rs
@@ -1,4 +1,4 @@
-use der::{self, DER};
+use crate::der::{self, DER};
 use std::io::{self, Read, Write};
 
 // Macro for lazy people like me
@@ -33,19 +33,19 @@ macro_rules! string_type {
                 der::ContentType::Primitive
             }
 
-            fn der_encode_content(&self, w: &mut Write) -> io::Result<()> {
-                try!(w.write(self.0.as_bytes()));
+            fn der_encode_content(&self, w: &mut dyn Write) -> io::Result<()> {
+                w.write(self.0.as_bytes())?;
                 Ok(())
             }
 
-            fn der_decode_content(r: &mut Read, length: usize) -> io::Result<$name> {
+            fn der_decode_content(r: &mut dyn Read, length: usize) -> io::Result<$name> {
                 let mut encoded = r.take(length as u64);
                 let mut buffer = String::new();
-                try!(encoded.read_to_string(&mut buffer));
+                encoded.read_to_string(&mut buffer)?;
                 Ok($name(buffer))
             }
         }
-    }
+    };
 }
 
 string_type!(NumericString);
@@ -66,8 +66,12 @@ mod tests {
     #[test]
     fn sample() {
         use der::DER;
-        let bytes = IA5String::from("FooBar123".to_string()).der_bytes().unwrap();
-        assert_eq!("FooBar123",
-                   &String::from(IA5String::der_from_bytes(bytes).unwrap()));
+        let bytes = IA5String::from("FooBar123".to_string())
+            .der_bytes()
+            .unwrap();
+        assert_eq!(
+            "FooBar123",
+            &String::from(IA5String::der_from_bytes(bytes).unwrap())
+        );
     }
 }

--- a/src/xer.rs
+++ b/src/xer.rs
@@ -8,23 +8,23 @@ pub trait XEREncodeable {
     fn xer_name(&self) -> String;
     /// Encode full tag
     fn xer_encode<W: Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
-        try!(stream.write(b"<"));
-        try!(stream.write(self.xer_name().as_bytes()));
-        try!(stream.write(b">"));
-        try!(self.xer_encode_content(stream));
-        try!(stream.write(b"</"));
-        try!(stream.write(self.xer_name().as_bytes()));
-        try!(stream.write(b">"));
+        stream.write(b"<")?;
+        stream.write(self.xer_name().as_bytes())?;
+        stream.write(b">")?;
+        self.xer_encode_content(stream)?;
+        stream.write(b"</")?;
+        stream.write(self.xer_name().as_bytes())?;
+        stream.write(b">")?;
         Ok(())
     }
 }
 
 impl XEREncodeable for bool {
     fn xer_encode_content<W: Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
-        try!(stream.write(match self {
+        stream.write(match self {
             &true => "True".as_bytes(),
             &false => "False".as_bytes(),
-        }));
+        })?;
         Ok(())
     }
 
@@ -35,7 +35,7 @@ impl XEREncodeable for bool {
 
 impl XEREncodeable for String {
     fn xer_encode_content<W: Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
-        try!(stream.write(self.as_bytes()));
+        stream.write(self.as_bytes())?;
         Ok(())
     }
 
@@ -46,7 +46,7 @@ impl XEREncodeable for String {
 
 impl XEREncodeable for i32 {
     fn xer_encode_content<W: Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
-        try!(stream.write(format!("{}", self).as_bytes()));
+        stream.write(format!("{}", self).as_bytes())?;
         Ok(())
     }
 
@@ -58,7 +58,7 @@ impl XEREncodeable for i32 {
 impl<T: XEREncodeable> XEREncodeable for Vec<T> {
     fn xer_encode_content<W: Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
         for item in self.iter() {
-            try!(item.xer_encode(stream));
+            item.xer_encode(stream)?;
         }
         Ok(())
     }
@@ -75,13 +75,13 @@ macro_rules! implement_xer {
         impl $crate::xer::XEREncodeable for $struct_name {
             fn xer_encode_content<W: ::std::io::Write>(&self, stream: &mut W) -> ::std::io::Result<()> {
                 $(
-                    try!(stream.write(b"<"));
-                    try!(stream.write(stringify!($field_name).to_string().as_bytes()));
-                    try!(stream.write(b">"));
-                    try!(self.$field_name.xer_encode_content(stream));
-                    try!(stream.write(b"</"));
-                    try!(stream.write(stringify!($field_name).to_string().as_bytes()));
-                    try!(stream.write(b">"));
+                    stream.write(b"<")?;
+                    stream.write(stringify!($field_name).to_string().as_bytes())?;
+                    stream.write(b">")?;
+                    self.$field_name.xer_encode_content(stream)?;
+                    stream.write(b"</")?;
+                    stream.write(stringify!($field_name).to_string().as_bytes())?;
+                    stream.write(b">")?;
                 )+
                 Ok(())
             }


### PR DESCRIPTION
- Replace deprecated `try!` macros with the `?` operator
- Use new Rust 2018 `use` syntax
- Add `dyn` keyword before trait objects
- Run rustfmt